### PR TITLE
fix: Cliff duration bug on vestingsV2 chart

### DIFF
--- a/src/components/Dashboard/Chart/Chart.js
+++ b/src/components/Dashboard/Chart/Chart.js
@@ -109,10 +109,10 @@ function getVestingDataV2(
   for (let i = 0; i < vestingDays; i++) {
     let vestedThatDay
 
-    if (i <= cliffEndDay) {
+    if (i < cliffEndDay) {
       vestedThatDay = 0
     } else {
-      const elapsedPeriods = (DAY_IN_SECONDS * (i + 1)) / periodDuration
+      const elapsedPeriods = (DAY_IN_SECONDS * i) / periodDuration
       const elapsedPeriodsTrunc = Math.trunc(elapsedPeriods)
 
       vestedThatDay = vestedPerPeriod


### PR DESCRIPTION
### Before
<img width="1094" alt="image" src="https://user-images.githubusercontent.com/45410089/208692487-b7c6d4c1-88ae-4ece-8923-88b687182d5a.png">
<img width="1094" alt="image" src="https://user-images.githubusercontent.com/45410089/208692134-f8375864-09fa-4b9c-9104-629ac340b33c.png">

### After
<img width="1094" alt="image" src="https://user-images.githubusercontent.com/45410089/208692251-e5ab597c-71bf-4399-979f-f0760e62d707.png">
<img width="1094" alt="image" src="https://user-images.githubusercontent.com/45410089/208692294-0d3d0c0f-75b9-40b2-930f-84c878240518.png">
